### PR TITLE
Update to ensure client.js is pulled from the node_modules/server-event/ directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var path = require('path');
 
 function prepareRequest(req, res) {
 	req.socket.setTimeout(Infinity);
@@ -16,7 +17,7 @@ module.exports = function (options) {
 	var retry        = parseInt(options.retry, 10) || 3000;
 
 	if (options.express) {
-		fs.readFile('client.js', function (error, data) {
+		fs.readFile(path.resolve(__dirname, 'client.js'), function (error, data) {
 			var clientJs;
 
 			if (error) {


### PR DESCRIPTION
Instead of from where the calling script is located.

I ran into an issue where I already had a `client.js` in my app directory, and was baffled as to why server-event was serving _that_ file instead of its own.
